### PR TITLE
close zipoutputfp at line 409. without the fix, cannot write the documen...

### DIFF
--- a/odf/opendocument.py
+++ b/odf/opendocument.py
@@ -408,6 +408,7 @@ class OpenDocument:
         """
         zipoutputfp = zipfile.ZipFile(outputfp,"w")
         self.__zipwrite(zipoutputfp)
+        zipoutputfp.close()
 
     def __zipwrite(self, outputfp):
         """ Write the document to an open file pointer


### PR DESCRIPTION
The bug has been diagnosed here: https://bitbucket.org/pypy/pypy/issue/1165/

And the bug has been reproduced here:https://travis-ci.org/chfw/pyexcel/jobs/34661942

Please include the simple fix so odf can be used to write open document under pypy.
