### PR TITLE
Fixed the AttributeError when initialize ODF2XHTML instance with embedable=True

### DIFF
--- a/odf/odf2xhtml.py
+++ b/odf/odf2xhtml.py
@@ -431,7 +431,7 @@ class ODF2XHTML(handler.ContentHandler):
         (TEXTNS, "user-index-source"):(self.s_text_x_source, self.e_text_x_source),
         }
         if embedable:
-            self.make_embedable()
+            self.set_embedable()
         self._resetobject()
 
     def set_plain(self):


### PR DESCRIPTION
Initialize ODF2XHTML instance with embedable=True then will raise an AttributeError, because there was no method named 'make_embedable', in fact we want to invoke set_embedable().
