### PR TITLE
fix to digest Mathml elements

### DIFF
--- a/odf/odf2xhtml.py
+++ b/odf/odf2xhtml.py
@@ -748,12 +748,15 @@ class ODF2XHTML(handler.ContentHandler):
         """
         objhref = attrs[(XLINKNS,"href")]
         # Remove leading "./": from "./Object 1" to "Object 1"
-#       objhref = objhref [2:]
+        # objhref = objhref [2:]
        
         # Not using os.path.join since it fails to find the file on Windows.
-#       objcontentpath = '/'.join([objhref, 'content.xml'])
-
-        for c in self.document.childnodes:
+        # objcontentpath = '/'.join([objhref, 'content.xml'])
+        ################################
+        # fixed: self.document.childnodes ===>  self.document.childobjects
+        # 2016-02-19 G.K.
+        ################################
+        for c in self.document.childobjects:
             if c.folder == objhref:
                 self._walknode(c.topnode)
 

--- a/odf/opendocument.py
+++ b/odf/opendocument.py
@@ -916,9 +916,17 @@ def __fixXmlPart(xmlpart):
                          u'svg', u'fo',u'draw', u'table',u'form')
     for prefix in requestedPrefixes:
         if u' xmlns:{prefix}'.format(prefix=prefix) not in xmlpart:
-            pos=result.index(u" xmlns:")
-            toInsert=u' xmlns:{prefix}="urn:oasis:names:tc:opendocument:xmlns:{prefix}:1.0"'.format(prefix=prefix)
-            result=result[:pos]+toInsert+result[pos:]
+            ###########################################
+            # fixed a bug triggered by math elements
+            # Notice: math elements are probably wrongly exported to XHTML
+            # 2016-02-19 G.K.
+            ###########################################
+            try:
+                pos=result.index(u" xmlns:")
+                toInsert=u' xmlns:{prefix}="urn:oasis:names:tc:opendocument:xmlns:{prefix}:1.0"'.format(prefix=prefix)
+                result=result[:pos]+toInsert+result[pos:]
+            except:
+                pass
     return result
 
 

--- a/odf/opendocument.py
+++ b/odf/opendocument.py
@@ -918,7 +918,8 @@ def __fixXmlPart(xmlpart):
         if u' xmlns:{prefix}'.format(prefix=prefix) not in xmlpart:
             ###########################################
             # fixed a bug triggered by math elements
-            # Notice: math elements are probably wrongly exported to XHTML
+            # Notice: math elements are creectly exported to XHTML
+            #         and best viewed with MathJax javascript.
             # 2016-02-19 G.K.
             ###########################################
             try:


### PR DESCRIPTION
odf2xhtml choked with Mathml formulas. Relaxed the correction of xmlns statements in that case (and other?)

Besides, self.document.childnodes was replaced by self.document.childobjects at a place where the first statement has no meaning.
