### PR TITLE
bug fix: there is no way to save or load a file that has a python 2 string name

### DIFF
--- a/odf/opendocument.py
+++ b/odf/opendocument.py
@@ -586,8 +586,6 @@ class OpenDocument:
         Writes the ZIP format
         @param outputfp open file descriptor
         """
-        assert('wb' in repr(outputfp) or 'BufferedWriter' in repr(outputfp)  or 'BytesIO' in repr(outputfp))
-
         zipoutputfp = zipfile.ZipFile(outputfp,"w")
         self.__zipwrite(zipoutputfp)
 
@@ -930,8 +928,6 @@ def __detectmimetype(zipfd, odffile):
     @return a mime-type as a unicode string
     """
     assert(isinstance(zipfd, zipfile.ZipFile))
-    assert(type(odffile)==type(u"") or 'rb' in repr(odffile) \
-               or 'BufferedReader' in repr(odffile)  or 'BytesIO' in repr(odffile))
 
     try:
         mimetype = zipfd.read('mimetype').decode("utf-8")
@@ -956,9 +952,6 @@ def load(odffile):
     an open readable stream
     @return a reference to the structure (an OpenDocument instance)
     """
-    assert(type(odffile)==type(u"") or 'rb' in repr(odffile) \
-               or 'BufferedReader' in repr(odffile)  or 'BytesIO' in repr(odffile))
-
     z = zipfile.ZipFile(odffile)
     mimetype = __detectmimetype(z, odffile)
     doc = OpenDocument(mimetype, add_generator=False)


### PR DESCRIPTION
I am not sure the reason why those assertions are there in the first place. Given Python heavily uses [duct typing](https://en.wikipedia.org/wiki/Duck_typing#In_Python), I would say please do it in C++. 

And it prevent you from doing the following basic things using python 2. Yes, it is a bug because odfpy v0.9.6 allows you do the following.

    >>> from odf.opendocument import load
    >>> load("abc.ods")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "odf/opendocument.py", line 960, in load
        or 'BufferedReader' in repr(odffile)  or 'BytesIO' in repr(odffile))
    AssertionError
    >>> from odf.opendocument import OpenDocumentSpreadsheet
    >>> book=OpenDocumentSpreadsheet()
    >>> book.write("abc.ods")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "odf/opendocument.py", line 589, in write
        assert('wb' in repr(outputfp) or 'BufferedWriter' in repr(outputfp)  or 'BytesIO' in repr(outputfp))
    AssertionError
    >>> 
