### PR TITLE
Use setuptools instead of distribute.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 #
 
 import platform
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 version = '1.3.4dev'
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 #
 
 import platform
-from setuptools import setup, find_packages
+from setuptools import setup
 
 version = '1.3.4dev'
 


### PR DESCRIPTION
HI!

I like very much setuptools'

    python setyp.py develop

in a virtualenv.

I've converted setup.py accordingly, run, and run tests. One (issue #8) failed, other are ok.

Best regards,
Evgeny