### PR TITLE
Clarify usage of bullets in non-numbering style

### DIFF
--- a/odf/easyliststyle.py
+++ b/odf/easyliststyle.py
@@ -35,7 +35,8 @@ Each item in the string (or array) represents a list level
  *
  * <p>If an item contains <code>1</code>, <code>I</code>,
  * <code>i</code>, <code>A</code>, or <code>a</code>, then it is presumed
- * to be a numbering style; otherwise it is a bulleted style.</p>
+ * to be a numbering style; otherwise it is a bulleted style based on the
+ * first character in the item.</p>
 """
 
 _MAX_LIST_LEVEL = 10


### PR DESCRIPTION
Precise that only the first character of the specifier is used as a bullet for the list level.