### PR TITLE
preserve whitespace when parsing an xml

### DIFF
--- a/odf/load.py
+++ b/odf/load.py
@@ -67,7 +67,7 @@ class LoadParser(handler.ContentHandler):
         self.level = self.level + 1
         # Add any accumulated text content
         content = ''.join(self.data)
-        if len(content.strip()) > 0:
+        if content:
             self.parent.addText(content, check_grammar=False)
             self.data = []
         # Create the element
@@ -106,7 +106,7 @@ class LoadParser(handler.ContentHandler):
             return
         self.level = self.level - 1
         str = ''.join(self.data)
-        if len(str.strip()) > 0:
+        if str:
             self.curr.addText(str, check_grammar=False)
         self.data = []
         self.curr = self.curr.parentNode

--- a/odf/opendocument.py
+++ b/odf/opendocument.py
@@ -369,7 +369,7 @@ class OpenDocument:
             stylenamelist = self._parseoneelement(top, stylenamelist)
         stylelist = []
         for e in self.automaticstyles.childNodes:
-            if e.getAttrNS(STYLENS,u'name') in stylenamelist:
+            if isinstance(e, element.Element) and e.getAttrNS(STYLENS,u'name') in stylenamelist:
                 stylelist.append(e)
 
         # check the type of the returned data


### PR DESCRIPTION
Documents containing `<text:span> </text:span>` are parsed as
`<text:span></text:span>`.  This commit fixes parsing by preserving all
whitespace. See also #52.