### PR TITLE
add parent attribute to Element

### DIFF
--- a/examples/passwd-as-ods.py
+++ b/examples/passwd-as-ods.py
@@ -19,46 +19,41 @@
 #
 
 from odf.opendocument import OpenDocumentSpreadsheet
-from odf.style import Style, TextProperties, ParagraphProperties, TableColumnProperties
+from odf.style import (ParagraphProperties, Style, TableColumnProperties,
+                       TextProperties)
+from odf.table import Table, TableCell, TableColumn, TableRow
 from odf.text import P
-from odf.table import Table, TableColumn, TableRow, TableCell
-
-PWENC = "utf-8"
 
 textdoc = OpenDocumentSpreadsheet()
 # Create a style for the table content. One we can modify
 # later in the word processor.
-tablecontents = Style(name="Table Contents", family="paragraph")
-tablecontents.addElement(ParagraphProperties(numberlines="false", linenumber="0"))
-tablecontents.addElement(TextProperties(fontweight="bold"))
-textdoc.styles.addElement(tablecontents)
+tablecontents = Style(parent=textdoc.styles,
+                      name='Table Contents', family='paragraph')
+ParagraphProperties(parent=tablecontents, numberlines='false', linenumber='0')
+TextProperties(parent=tablecontents, fontweight='bold')
 
 # Create automatic styles for the column widths.
 # We want two different widths, one in inches, the other one in metric.
 # ODF Standard section 15.9.1
-widthshort = Style(name="Wshort", family="table-column")
-widthshort.addElement(TableColumnProperties(columnwidth="1.7cm"))
-textdoc.automaticstyles.addElement(widthshort)
+widthshort = Style(parent=textdoc.automaticstyles,
+                   name='Wshort', family='table-column')
+TableColumnProperties(parent=widthshort, columnwidth='1.7cm')
 
-widthwide = Style(name="Wwide", family="table-column")
-widthwide.addElement(TableColumnProperties(columnwidth="1.5in"))
-textdoc.automaticstyles.addElement(widthwide)
+widthwide = Style(parent=textdoc.automaticstyles,
+                  name='Wwide', family='table-column')
+TableColumnProperties(parent=widthwide, columnwidth='1.5in')
 
 # Start the table, and describe the columns
-table = Table(name="Password")
-table.addElement(TableColumn(numbercolumnsrepeated=4,stylename=widthshort))
-table.addElement(TableColumn(numbercolumnsrepeated=3,stylename=widthwide))
+table = Table(parent=textdoc.spreadsheet, name='Password')
+TableColumn(parent=table, numbercolumnsrepeated=4, stylename=widthshort)
+TableColumn(parent=table, numbercolumnsrepeated=3, stylename=widthwide)
 
-f = open('/etc/passwd')
-for line in f:
-    rec = line.strip().split(":")
-    tr = TableRow()
-    table.addElement(tr)
-    for val in rec:
-        tc = TableCell()
-        tr.addElement(tc)
-        p = P(stylename=tablecontents,text=unicode(val,PWENC))
-        tc.addElement(p)
+with open('/etc/passwd') as f:
+    for line in f:
+        rec = line.strip().split(':')
+        tr = TableRow(parent=table)
+        for val in rec:
+            tc = TableCell(parent=tr)
+            p = P(parent=tc, stylename=tablecontents, text=val)
 
-textdoc.spreadsheet.addElement(table)
-textdoc.save("passwd.ods")
+textdoc.save('passwd.ods')

--- a/odf/element.py
+++ b/odf/element.py
@@ -260,7 +260,7 @@ class Text(Childless, Node):
         """ Write XML in UTF-8 """
         if self.data:
             f.write(_escape(unicode(self.data)))
-    
+
 class CDATASection(Text, Childless):
     nodeType = Node.CDATA_SECTION_NODE
 
@@ -289,7 +289,7 @@ class Element(Node):
                          Node.TEXT_NODE,
                          Node.CDATA_SECTION_NODE,
                          Node.ENTITY_REFERENCE_NODE)
-    
+
     def __init__(self, attributes=None, text=None, cdata=None, qname=None, qattributes=None, check_grammar=True, **args):
         if qname is not None:
             self.qname = qname
@@ -340,7 +340,7 @@ class Element(Node):
         for ns,p in nsdict.items():
             if p == prefix: return ns
         return None
-        
+
     def get_nsprefix(self, namespace):
         """ Odfpy maintains a list of known namespaces. In some cases we have a namespace URL,
             and needs to look up or assign the prefix for it.
@@ -358,7 +358,7 @@ class Element(Node):
         element.ownerDocument = self.ownerDocument
         for child in element.childNodes:
             self._setOwnerDoc(child)
-        
+
     def addElement(self, element, check_grammar=True):
         """ adds an element to an Element
 
@@ -416,20 +416,23 @@ class Element(Node):
             library will add the correct namespace.
             Must overwrite, If attribute already exists.
         """
-        allowed_attrs = self.allowed_attributes()
-        if allowed_attrs is None:
-            if type(attr) == type(()):
-                prefix, localname = attr
-                self.setAttrNS(prefix, localname, value)
-            else:
-                raise AttributeError( "Unable to add simple attribute - use (namespace, localpart)")
+        if attr == 'parent' and value is not None:
+            value.addElement(self)
         else:
-            # Construct a list of allowed arguments
-            allowed_args = [ a[1].lower().replace('-','') for a in allowed_attrs]
-            if check_grammar and attr not in allowed_args:
-                raise AttributeError( "Attribute %s is not allowed in <%s>" % ( attr, self.tagName))
-            i = allowed_args.index(attr)
-            self.setAttrNS(allowed_attrs[i][0], allowed_attrs[i][1], value)
+            allowed_attrs = self.allowed_attributes()
+            if allowed_attrs is None:
+                if type(attr) == type(()):
+                    prefix, localname = attr
+                    self.setAttrNS(prefix, localname, value)
+                else:
+                    raise AttributeError( "Unable to add simple attribute - use (namespace, localpart)")
+            else:
+                # Construct a list of allowed arguments
+                allowed_args = [ a[1].lower().replace('-','') for a in allowed_attrs]
+                if check_grammar and attr not in allowed_args:
+                    raise AttributeError( "Attribute %s is not allowed in <%s>" % ( attr, self.tagName))
+                i = allowed_args.index(attr)
+                self.setAttrNS(allowed_attrs[i][0], allowed_attrs[i][1], value)
 
     def setAttrNS(self, namespace, localpart, value):
         """ Add an attribute to the element
@@ -537,5 +540,3 @@ class Element(Node):
         """ This is a check to see if the object is an instance of a type """
         obj = element(check_grammar=False)
         return self.qname == obj.qname
-
-


### PR DESCRIPTION
Add a 'parent' attribute to Element that allows auto-addElement (the old syntax is still supported).

AFAIK 'parent' is not an attribute of any OpenDocument element, so we can use it to specify the Element in which to be created.

See the example passwd-as-ods.py:
```
f = open('/etc/passwd')
for line in f:
    rec = line.strip().split(":")
    tr = TableRow()
    table.addElement(tr)
    for val in rec:
        tc = TableCell()
        tr.addElement(tc)
        p = P(stylename=tablecontents,text=unicode(val,PWENC))
        tc.addElement(p)
```

becomes

```
with open('/etc/passwd') as f:
    for line in f:
        rec = line.strip().split(':')
        tr = TableRow(parent=table)
        for val in rec:
            tc = TableCell(parent=tr)
            p = P(parent=tc, stylename=tablecontents, text=val)
```

I haven't updated every example and documentation yet, because I wanted to get your opinion on this API change.