### PR TITLE
Update caches instead of clearing them when calling removeChild()

### DIFF
--- a/odf/element.py
+++ b/odf/element.py
@@ -233,7 +233,7 @@ class Node(xml.dom.Node):
             oldChild.previousSibling.nextSibling = oldChild.nextSibling
         oldChild.nextSibling = oldChild.previousSibling = None
         if self.ownerDocument:
-            self.ownerDocument.clear_caches()
+            self.ownerDocument.remove_from_caches(oldChild)
         oldChild.parentNode = None
         return oldChild
 

--- a/odf/opendocument.py
+++ b/odf/opendocument.py
@@ -194,6 +194,23 @@ class OpenDocument:
         if styleref is not None and styleref in self._styles_ooo_fix:
             elt.setAttrNS(TEXTNS,u'style-name', self._styles_ooo_fix[styleref])
 
+    def remove_from_caches(self, elt):
+        """
+        Updates internal caches when an element has been removed
+        @param elt an element.Element instance
+        """
+        # See remark in build_caches about the following assertion
+        import odf.element
+        assert(isinstance(elt, element.Element) or isinstance(elt, odf.element.Element))
+
+        self.element_dict[elt.qname].remove(elt)
+        for e in elt.childNodes:
+            if e.nodeType == element.Node.ELEMENT_NODE:
+                self.remove_from_caches(e)
+
+        if elt.qname == (STYLENS, u'style'):
+            del self._styles_dict[elt.getAttrNS(STYLENS, u'name')]
+
     def __register_stylename(self, elt):
         '''
         Register a style. But there are three style dictionaries:


### PR DESCRIPTION
This prevents cache corruptions when an element is removed and another
one is immediately added to a document. In such a situation, the element
cache of the document only contains the latter element. Since this cache
is not empty any more, further calls to other methods (such as
getElementsByType) do not trigger cache rebuilding, yielding to
incorrect results.

For the moment, the following code fails:
```python
import odf.opendocument
import odf.text
doc = odf.opendocument.OpenDocumentText()
p1 = odf.text.P(parent=doc.text, text="foo")
p2 = odf.text.P(parent=doc.text, text="bar")
p1.parentNode.removeChild(p1)
p3 = odf.text.P(parent=doc.text, text="baz")
assert(list(doc.getElementsByType(odf.text.P)) == [p2, p3])
```
because the call to removeChild(p1) clears doc.element_dict, then p3 creation adds p3 to doc.element_dict. When doc.element_dict is empty, the call to getElementsByType triggers a cache rebuilding. Yet, this does not happen because of p3 addition.