### PR TITLE
Error when merging pictures

### DIFF
--- a/examples/odtmerge.py
+++ b/examples/odtmerge.py
@@ -60,7 +60,7 @@ def merge(inputfile, textdoc):
     for body in inputtextdoc.body.childNodes[:]:
         textdoc.body.addElement(body)
 
-    textdoc.Pictures = inputtextdoc.Pictures
+    textdoc.Pictures.update(inputtextdoc.Pictures)
     return textdoc
 
 


### PR DESCRIPTION
There was an error when merging pictures. If multiple files where merged the picture dictionary was always overwritten by the last inputtextdoc. Call dictionary method update instead to concat the textdoc and inputtextdoc dictionaries.