### PR TITLE
fix a bug about loading a document in memory

### DIFF
--- a/odf/odf2xhtml.py
+++ b/odf/odf2xhtml.py
@@ -1445,10 +1445,7 @@ ol, ul { padding-left: 2em; }
 
         self.lines = []
         self._wfunc = self._wlines
-        if type(odffile)==type(u""):
-            self.document = load(odffile)
-        else:
-            self.document = odffile
+        self.document = load(odffile)
         self._walknode(self.document.topnode)
 
     def _walknode(self, node):


### PR DESCRIPTION
There was an error when loading a document in memory. If 'odffile' is a file in the disk, there is no problem. But, if 'odffile' is a document in memory, it is a stream in memory. It will just load the stream name, the instance name, not the stream itself.