### PR TITLE
add scale-to-X and scale-to-Y attributes to page-layout-properties

### DIFF
--- a/odf/attrconverters.py
+++ b/odf/attrconverters.py
@@ -785,6 +785,8 @@ attrconverters = {
 	((FORMNS,u'xforms-submission'), None): cnv_string,
         ((GRDDLNS,u'transformation'), None): cnv_string,
 	((LOEXTNS,u'contextual-spacing'), None): cnv_boolean,
+        ((LOEXTNS,u'scale-to-X'), None): cnv_string,
+        ((LOEXTNS,u'scale-to-Y'), None): cnv_string,
 	((MANIFESTNS,u'algorithm-name'), None): cnv_string,
 	((MANIFESTNS,u'checksum'), None): cnv_string,
 	((MANIFESTNS,u'checksum-type'), None): cnv_string,

--- a/odf/grammar.py
+++ b/odf/grammar.py
@@ -7434,6 +7434,8 @@ allowed_attributes = {
 		(STYLENS,u'shadow'),
 		(STYLENS,u'table-centering'),
 		(STYLENS,u'writing-mode'),
+                (LOEXTNS,u'scale-to-X'),
+                (LOEXTNS,u'scale-to-Y')
 	),
 # allowed_attributes
 	(STYLENS,u'paragraph-properties'): (

--- a/odf/namespaces.py
+++ b/odf/namespaces.py
@@ -82,6 +82,7 @@ nsdict = {
    FORMXNS: u'formx',
    GRDDLNS: u'grddl',
    KOFFICENS: u'koffice',
+   LOEXTNS: u'loext',
    MANIFESTNS: u'manifest',
    MATHNS: u'math',
    METANS: u'meta',


### PR DESCRIPTION
This would allow odpfy to create spreadsheet documents with the option "fit print range to width/height" as supported by LibreOfficeCalc [since at least 2004](https://github.com/LibreOffice/core/commit/a9232bb320b7bfb1bec7b823fae802cd75e5fd54).